### PR TITLE
feat: end-to-end API types via Eden Treaty

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -1,6 +1,9 @@
 {
   "name": "api",
   "version": "1.0.50",
+  "exports": {
+    "./app": "./src/index.ts"
+  },
   "scripts": {
     "dev": "bun run --watch src/index.ts",
     "typecheck": "tsc --noEmit"

--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -20,6 +20,10 @@ const app = new Elysia()
   .use(hlsRoute)
   .use(videoRoute)
 
+// Exported for Eden Treaty so the web client can infer request/response
+// types directly from these route handlers.
+export type App = typeof app
+
 async function start() {
   try {
     logger.info("initializing services")

--- a/apps/api/src/modules/upload/service.ts
+++ b/apps/api/src/modules/upload/service.ts
@@ -87,6 +87,15 @@ export const uploadService = {
       sizeBytes: file.size,
     })
 
-    return { message: "Video uploaded successfully", video }
+    return {
+      message: "Video uploaded successfully",
+      video: {
+        id: video.id,
+        title: video.title,
+        status: video.status,
+        createdAt: video.createdAt.toISOString(),
+        updatedAt: video.updatedAt.toISOString(),
+      },
+    }
   },
 }

--- a/apps/api/src/modules/videos/repository.ts
+++ b/apps/api/src/modules/videos/repository.ts
@@ -27,6 +27,7 @@ export const videoRepository = {
 
   create: async (data: NewVideo): Promise<VideoRecord> => {
     const [row] = await db.insert(videos).values(data).returning()
+    if (!row) throw new Error("Insert returned no row")
     return row
   },
 

--- a/apps/api/src/modules/videos/service.ts
+++ b/apps/api/src/modules/videos/service.ts
@@ -11,32 +11,23 @@ const log = logger.child({ module: "videos.service" })
 
 const PRESIGN_TTL_SEC = 600
 
-interface VideoResponse {
-  id: number
-  title: string
-  status: string
-  createdAt: Date
-  updatedAt: Date
-  videoUrl: string | null
-  duration: number | null
-  thumbnailUrl: string | null
-  seekingPreviewUrl: string | null
-  seekingPreviewInterval: number | null
-  seekingPreviewColumns: number | null
-  seekingPreviewTotalFrames: number | null
-  seekingPreviewTileWidth: number | null
-  seekingPreviewTileHeight: number | null
-  hlsUrl: string | null
-  hlsVariants: object[] | null
+// Inline shape (not a named export) so Eden Treaty's inferred response type
+// stays structural — named types local to this file can't be re-exported
+// from `api/app` for web consumers.
+type HlsVariantShape = {
+  name: string
+  width: number
+  height: number
+  bitrate: number
 }
 
-async function attachVideoUrls(video: VideoRecord): Promise<VideoResponse> {
+async function attachVideoUrls(video: VideoRecord) {
   const base = {
     id: video.id,
     title: video.title,
     status: video.status,
-    createdAt: video.createdAt,
-    updatedAt: video.updatedAt,
+    createdAt: video.createdAt.toISOString(),
+    updatedAt: video.updatedAt.toISOString(),
     duration: video.duration,
     seekingPreviewInterval: video.seekingPreviewInterval,
     seekingPreviewColumns: video.seekingPreviewColumns,
@@ -62,8 +53,8 @@ async function attachVideoUrls(video: VideoRecord): Promise<VideoResponse> {
       seekingPreviewUrl,
       hlsUrl: video.hlsPath ? `/videos/${video.id}/hls/master.m3u8` : null,
       hlsVariants: video.hlsVariants
-        ? (JSON.parse(video.hlsVariants) as object[])
-        : null,
+        ? (JSON.parse(video.hlsVariants) as HlsVariantShape[])
+        : (null as HlsVariantShape[] | null),
     }
   } catch (err) {
     log.error("failed to attach video URLs", {

--- a/apps/web/app/watch/page.tsx
+++ b/apps/web/app/watch/page.tsx
@@ -16,8 +16,7 @@ export const generateMetadata = async ({ searchParams }: PageProps) => {
     const res = await videosApi.get(videoId)
     return {
       title: res.video.title,
-      description:
-        res.video.description || "Watch this video on our platform.",
+      description: "Watch this video on our platform.",
     }
   } catch {
     return { title: "Failed to Load Video" }
@@ -51,17 +50,10 @@ export default async function Page({ searchParams }: PageProps) {
             thumbnailUrl={res.video.thumbnailUrl ?? null}
             seekingPreviewUrl={res.video.seekingPreviewUrl ?? null}
             previewConfig={{
-              ...(res.preview ?? {}),
-              frameIntervalSeconds:
-                res.video.seekingPreviewInterval ??
-                res.preview?.frameIntervalSeconds ??
-                0,
-              columnsPerRow:
-                res.video.seekingPreviewColumns ??
-                res.preview?.columnsPerRow ??
-                10,
-              tileWidth: res.preview?.tileWidth ?? 160,
-              tileHeight: res.preview?.tileHeight ?? 90,
+              frameIntervalSeconds: res.video.seekingPreviewInterval ?? 0,
+              columnsPerRow: res.video.seekingPreviewColumns ?? 10,
+              tileWidth: 160,
+              tileHeight: 90,
               totalFrames: res.video.seekingPreviewTotalFrames,
               tileWidthActual: res.video.seekingPreviewTileWidth,
               tileHeightActual: res.video.seekingPreviewTileHeight,

--- a/apps/web/components/video/upload.tsx
+++ b/apps/web/components/video/upload.tsx
@@ -2,7 +2,7 @@
 
 import React from "react"
 import { UploadCloud, FileVideo, CheckCircle2, X } from "lucide-react"
-import type { VideosResponse } from "@/services/video/types"
+import type { Video, VideosResponse } from "@/services/video/types"
 import { Button } from "@workspace/ui/components/button"
 import { Card, CardContent } from "@workspace/ui/components/card"
 import { Progress } from "@workspace/ui/components/progress"
@@ -31,7 +31,7 @@ export function UploadVideo() {
     await queryClient.cancelQueries({ queryKey: ["videos"] })
     const previous = queryClient.getQueryData<VideosResponse>(["videos"])
 
-    const placeholder = {
+    const placeholder: Video = {
       id: tempId,
       title: selectedFile.name,
       status: "uploading",
@@ -46,6 +46,8 @@ export function UploadVideo() {
       seekingPreviewTotalFrames: null,
       seekingPreviewTileWidth: null,
       seekingPreviewTileHeight: null,
+      hlsUrl: null,
+      hlsVariants: null,
     }
 
     queryClient.setQueryData<VideosResponse>(["videos"], (old) => {

--- a/apps/web/lib/api/client.ts
+++ b/apps/web/lib/api/client.ts
@@ -18,34 +18,51 @@ export class ApiError extends Error {
   }
 }
 
-export async function apiFetch<T>(
-  path: string,
-  init?: RequestInit
-): Promise<T> {
-  const res = await fetch(`${API_BASE_URL}${path}`, init)
-  if (!res.ok) {
-    throw new ApiError(`Request failed: ${path}`, res.status)
+interface EdenResult<T> {
+  data: T | null
+  error: { status: unknown; value: unknown } | null
+}
+
+function extractErrorMessage(value: unknown): string | null {
+  if (!value || typeof value !== "object") return null
+  if (!("error" in value)) return null
+  const err = (value as { error: unknown }).error
+  return typeof err === "string" ? err : null
+}
+
+/**
+ * Unwrap a treaty response: throws ApiError on non-2xx, returns data otherwise.
+ * React Query relies on throws for its error channel, so hooks consume this
+ * instead of the `{ data, error }` tuple directly.
+ */
+export function unwrap<T>(result: EdenResult<T>): T {
+  if (result.error) {
+    const status =
+      typeof result.error.status === "number" ? result.error.status : 500
+    const message =
+      extractErrorMessage(result.error.value) ?? `Request failed (${status})`
+    throw new ApiError(message, status)
   }
-  return res.json() as Promise<T>
+  return result.data as T
 }
 
-interface UploadOptions {
-  onProgress?: (percent: number) => void
-  signal?: AbortSignal
-}
-
+/**
+ * XHR-backed upload that reports progress. Eden Treaty uses fetch under the
+ * hood, which doesn't expose upload progress events, so uploads still go
+ * through XHR. The response type is imported from Eden so it stays in sync
+ * with the API.
+ */
 export function apiUpload<T>(
   path: string,
   formData: FormData,
-  { onProgress, signal }: UploadOptions = {}
+  { onProgress, signal }: { onProgress?: (p: number) => void; signal?: AbortSignal } = {}
 ): Promise<T> {
   return new Promise<T>((resolve, reject) => {
     const xhr = new XMLHttpRequest()
 
     xhr.upload.onprogress = (event) => {
       if (!event.lengthComputable) return
-      const percent = Math.round((event.loaded / event.total) * 100)
-      onProgress?.(percent)
+      onProgress?.(Math.round((event.loaded / event.total) * 100))
     }
 
     xhr.onload = () => {
@@ -61,8 +78,7 @@ export function apiUpload<T>(
     }
 
     xhr.onerror = () => reject(new Error("Network error during upload"))
-    xhr.onabort = () =>
-      reject(new DOMException("Upload aborted", "AbortError"))
+    xhr.onabort = () => reject(new DOMException("Upload aborted", "AbortError"))
 
     signal?.addEventListener("abort", () => xhr.abort())
 
@@ -70,4 +86,3 @@ export function apiUpload<T>(
     xhr.send(formData)
   })
 }
-

--- a/apps/web/lib/api/videos.ts
+++ b/apps/web/lib/api/videos.ts
@@ -1,36 +1,25 @@
-import type { VideosResponse, Video } from "@/services/video/types"
-import { apiFetch, apiUpload } from "./client"
+import { treaty } from "@elysiajs/eden"
+import type { App } from "api/app"
+import { API_BASE_URL, apiUpload, unwrap } from "./client"
 
-export interface VideoDetailResponse {
-  message: string
-  preview?: {
-    frameIntervalSeconds?: number
-    columnsPerRow: number
-    tileWidth: number
-    tileHeight: number
-  }
-  video: Video & { description?: string; hlsUrl?: string | null }
-}
-
-export interface UploadVideoResponse {
-  message: string
-  video: {
-    id: number
-    title: string
-    status: string
-    createdAt: string
-    updatedAt: string
-  }
-}
+// Eden Treaty client is kept module-local: exporting it tripped TS2742
+// (inferred type cannot be named without deep references to Eden internals).
+// Instead, expose typed helpers and derived types.
+const api = treaty<App>(API_BASE_URL)
 
 export const videosApi = {
-  list: () => apiFetch<VideosResponse>("/videos"),
+  list: async (opts: { page?: number; pageSize?: number } = {}) =>
+    unwrap(
+      await api.videos.get({
+        query: { page: opts.page ?? 1, pageSize: opts.pageSize ?? 20 },
+      })
+    ),
 
-  get: (videoId: string | number) =>
-    apiFetch<VideoDetailResponse>(`/videos/${videoId}`),
+  get: async (videoId: string | number) =>
+    unwrap(await api.videos({ id: String(videoId) }).get()),
 
-  delete: (videoId: string | number) =>
-    apiFetch<{ message: string }>(`/videos/${videoId}`, { method: "DELETE" }),
+  delete: async (videoId: string | number) =>
+    unwrap(await api.videos({ id: String(videoId) }).delete()),
 
   upload: (
     file: File,
@@ -38,6 +27,14 @@ export const videosApi = {
   ) => {
     const form = new FormData()
     form.append("file", file)
-    return apiUpload<UploadVideoResponse>("/upload/video", form, opts)
+    type UploadResponse = NonNullable<
+      Awaited<ReturnType<typeof api.upload.video.post>>["data"]
+    >
+    return apiUpload<UploadResponse>("/upload/video", form, opts)
   },
 }
+
+export type VideosResponse = Awaited<ReturnType<typeof videosApi.list>>
+export type VideoDetailResponse = Awaited<ReturnType<typeof videosApi.get>>
+export type Video = VideosResponse["videos"][number]
+export type UploadedVideo = Awaited<ReturnType<typeof videosApi.upload>>["video"]

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -12,8 +12,10 @@
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {
+    "@elysiajs/eden": "^1.4",
     "@tanstack/react-query": "^5.96.2",
     "@workspace/ui": "workspace:*",
+    "api": "workspace:*",
     "hls.js": "^1.6.15",
     "lucide-react": "^1.7.0",
     "next": "16.1.6",

--- a/apps/web/services/video/types.ts
+++ b/apps/web/services/video/types.ts
@@ -1,27 +1,8 @@
-export interface Video {
-  id: number
-  title: string
-  status: string
-  createdAt: string
-  updatedAt: string
-  videoUrl: string | null
-  duration: number | null
-  thumbnailUrl: string | null
-  seekingPreviewUrl: string | null
-  seekingPreviewInterval: number | null
-  seekingPreviewColumns: number | null
-  seekingPreviewTotalFrames: number | null
-  seekingPreviewTileWidth: number | null
-  seekingPreviewTileHeight: number | null
-}
-
-export interface VideosResponse {
-  message: string
-  preview: {
-    frameIntervalSeconds?: number
-    columnsPerRow: number
-    tileWidth: number
-    tileHeight: number
-  }
-  videos: Video[]
-}
+// Types inferred from the Elysia route tree via Eden Treaty. See
+// apps/web/lib/api/videos.ts for the source of truth.
+export type {
+  Video,
+  VideosResponse,
+  VideoDetailResponse,
+  UploadedVideo,
+} from "@/lib/api/videos"

--- a/packages/shared/src/config/index.ts
+++ b/packages/shared/src/config/index.ts
@@ -68,7 +68,7 @@ for (const envPath of envCandidates) {
     const key = trimmed.slice(0, eqIndex)
     const value = trimmed.slice(eqIndex + 1)
 
-    if (process.env[key] == null && Bun.env[key] == null) {
+    if (process.env[key] == null) {
       process.env[key] = value
     }
   }
@@ -152,8 +152,8 @@ const envSchema = z.object({
 })
 
 function parseEnv() {
-  const source = { ...Bun.env, ...process.env }
-  const result = envSchema.safeParse(source)
+  // Bun populates process.env identically to Bun.env, so this works in both.
+  const result = envSchema.safeParse(process.env)
   if (!result.success) {
     const issues = result.error.issues
       .map((issue) => `  - ${issue.path.join(".")}: ${issue.message}`)

--- a/packages/shared/src/logger/index.ts
+++ b/packages/shared/src/logger/index.ts
@@ -23,10 +23,11 @@ interface Logger {
   child: (defaultCtx: Record<string, unknown>) => Logger
 }
 
+// Bun populates `process.env`, so reading from it keeps this file free of
+// Bun-specific globals and compilable from non-Bun runtimes (e.g. Next.js'
+// tsc walking into this file via a type import).
 const minLevel: LogLevel =
-  ((globalThis.process?.env?.LOG_LEVEL ?? Bun.env.LOG_LEVEL) as
-    | LogLevel
-    | undefined) ?? "info"
+  (globalThis.process?.env?.LOG_LEVEL as LogLevel | undefined) ?? "info"
 
 function emit(entry: LogEntry) {
   const out = JSON.stringify(entry)

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -69,12 +69,18 @@ importers:
 
   apps/web:
     dependencies:
+      '@elysiajs/eden':
+        specifier: ^1.4
+        version: 1.4.9(elysia@1.4.28(@sinclair/typebox@0.34.49)(exact-mirror@0.2.7(@sinclair/typebox@0.34.49))(file-type@22.0.0)(openapi-types@12.1.3)(typescript@5.9.3))
       '@tanstack/react-query':
         specifier: ^5.96.2
         version: 5.96.2(react@19.2.4)
       '@workspace/ui':
         specifier: workspace:*
         version: link:../../packages/ui
+      api:
+        specifier: workspace:*
+        version: link:../api
       hls.js:
         specifier: ^1.6.15
         version: 1.6.15
@@ -524,6 +530,11 @@ packages:
     resolution: {integrity: sha512-lQfad+F3r4mNwsxRKbXyJB8Jg43oAOXjRwn7sKUL6bcOW3KjUqUimTS+woNpO97efpzjtDE0tEjGk9DTw8lqTQ==}
     peerDependencies:
       elysia: '>= 1.4.0'
+
+  '@elysiajs/eden@1.4.9':
+    resolution: {integrity: sha512-3CKVD4ycVjB8nCNssfmhnUuq3SzSHkUES3v5PNCFr9LxIrx39/HVRAZ8z2sLxrFqzUs48dCBZaxoZzJ5UUVHDA==}
+    peerDependencies:
+      elysia: '>=1.4.19'
 
   '@elysiajs/openapi@1.4.14':
     resolution: {integrity: sha512-kWmJWdvP8/LwHwAJXSpz6xFfYUoyUyEPRimEYABuDU1rOnS27Da1u9T2jyU7frOopxKWV/wDfDxMP8z2xdCPJw==}
@@ -5698,6 +5709,10 @@ snapshots:
       '@noble/ciphers': 1.3.0
 
   '@elysiajs/cors@1.4.1(elysia@1.4.28(@sinclair/typebox@0.34.49)(exact-mirror@0.2.7(@sinclair/typebox@0.34.49))(file-type@22.0.0)(openapi-types@12.1.3)(typescript@5.9.3))':
+    dependencies:
+      elysia: 1.4.28(@sinclair/typebox@0.34.49)(exact-mirror@0.2.7(@sinclair/typebox@0.34.49))(file-type@22.0.0)(openapi-types@12.1.3)(typescript@5.9.3)
+
+  '@elysiajs/eden@1.4.9(elysia@1.4.28(@sinclair/typebox@0.34.49)(exact-mirror@0.2.7(@sinclair/typebox@0.34.49))(file-type@22.0.0)(openapi-types@12.1.3)(typescript@5.9.3))':
     dependencies:
       elysia: 1.4.28(@sinclair/typebox@0.34.49)(exact-mirror@0.2.7(@sinclair/typebox@0.34.49))(file-type@22.0.0)(openapi-types@12.1.3)(typescript@5.9.3)
 


### PR DESCRIPTION
## Summary

Swap the hand-maintained API response types in \`apps/web\` for [Eden Treaty](https://elysiajs.com/eden/treaty/overview). Types now flow directly from Elysia route handlers — single source of truth in \`apps/api/src/index.ts\`, no more drift between API output and web consumers.

### apps/api
- Export \`type App = typeof app\` and expose it via \`package.json\` \`\"./app\"\`
- \`videos/service.ts\`: return ISO strings (matches the wire), use an inline \`HlsVariantShape\` so the inferred response re-exports cleanly
- \`upload/service.ts\`: return a projected 5-field video — \`rawPath\` and internal error messages no longer leak
- \`videos/repository.ts\`: \`create\` throws on empty insert (stricter contract)

### apps/web
- Add \`@elysiajs/eden\` + \`api\` workspace dep
- \`lib/api/client.ts\`: \`unwrap()\` converts Eden's \`{ data, error }\` into throws so React Query's error channel works unchanged. Keep the XHR \`apiUpload\` helper since fetch can't report upload progress
- \`lib/api/videos.ts\`: module-local \`treaty<App>\` client, typed helpers for list/get/delete/upload. Response types derived via \`Awaited<ReturnType<...>>\` — zero hand-written interfaces
- \`services/video/types.ts\`: re-exports the derived types, so existing call sites keep working
- \`app/watch/page.tsx\`: drop ghost \`description\` / \`preview\` fields that the API never returned
- \`components/video/upload.tsx\`: annotate the optimistic placeholder as \`Video\` and fill in the \`hlsUrl\` / \`hlsVariants\` fields the type requires

### packages/shared
- \`logger\` and \`config\` no longer reference \`Bun.env\` directly. \`process.env\` carries the same values and keeps these files compilable from Next's tsc (which walks into them via the \`App\` type import)

## Test plan

- [ ] \`pnpm typecheck\` — clean across 6 packages
- [ ] \`pnpm lint\` — 0 errors
- [ ] \`pnpm docker:up && pnpm dev:all\`
- [ ] Upload a video → optimistic card appears → processing → \`completed\`
- [ ] \`/watch?v=...\` → video + sprite preview work
- [ ] Delete a video → gone
- [ ] \`curl /upload/video\` response no longer contains \`rawPath\` (privacy fix)

🤖 Generated with [Claude Code](https://claude.com/claude-code)