### PR TITLE
fix(docker,web): healthy api container + correct URL resolution across SSR/browser

### DIFF
--- a/apps/web/app/watch/page.tsx
+++ b/apps/web/app/watch/page.tsx
@@ -1,5 +1,4 @@
 import { LazyPlayer } from "@/components/player/lazy-player"
-import { apiUrl } from "@/lib/api/client"
 import { videosApi } from "@/lib/api/videos"
 
 interface PageProps {
@@ -41,15 +40,13 @@ export default async function Page({ searchParams }: PageProps) {
 
   try {
     const res = await videosApi.get(videoId)
-    const videoUrl = res.video.videoUrl ? apiUrl(res.video.videoUrl) : null
-    const hlsUrl = res.video.hlsUrl ? apiUrl(res.video.hlsUrl) : null
 
     return (
       <div className="flex flex-col gap-4 px-4 py-6 lg:flex-row">
         <div className="col-span-3 flex w-full flex-col gap-2">
           <LazyPlayer
-            videoUrl={videoUrl ?? ""}
-            hlsUrl={hlsUrl}
+            videoPath={res.video.videoUrl ?? ""}
+            hlsPath={res.video.hlsUrl ?? null}
             duration={res.video.duration ?? 0}
             thumbnailUrl={res.video.thumbnailUrl ?? null}
             seekingPreviewUrl={res.video.seekingPreviewUrl ?? null}

--- a/apps/web/components/player/lazy-player.tsx
+++ b/apps/web/components/player/lazy-player.tsx
@@ -14,22 +14,45 @@ const Player = dynamic(
   }
 )
 
+// Read at client runtime — Next inlines NEXT_PUBLIC_* into the client bundle.
+// Resolving the prefix here (instead of in server components) means SSR bakes
+// plain paths into markup, so the URL the browser fetches is always the
+// browser-reachable host, without any context-aware juggling on the server.
+const PUBLIC_API_URL =
+  process.env.NEXT_PUBLIC_API_URL ?? "http://localhost:4000"
+
+function withBase(path: string | null): string {
+  if (!path) return ""
+  return /^https?:\/\//.test(path) ? path : `${PUBLIC_API_URL}${path}`
+}
+
 interface LazyPlayerProps {
-  videoUrl: string
-  hlsUrl: string | null
+  /** API path like "/videos/46/stream" — prefixed with the public host here. */
+  videoPath: string
+  /** API path like "/videos/46/hls/master.m3u8" — prefixed here. */
+  hlsPath: string | null
   duration: number
+  /** Already absolute (presigned MinIO URL). */
   thumbnailUrl: string | null
+  /** Already absolute (presigned MinIO URL). */
   seekingPreviewUrl: string | null
   previewConfig: PreviewConfig
 }
 
 export function LazyPlayer({
+  videoPath,
+  hlsPath,
   seekingPreviewUrl,
   ...rest
 }: LazyPlayerProps) {
   return (
     <PlayerErrorBoundary>
-      <Player seekingPreviewUrl={seekingPreviewUrl ?? ""} {...rest} />
+      <Player
+        videoUrl={withBase(videoPath)}
+        hlsUrl={hlsPath ? withBase(hlsPath) : null}
+        seekingPreviewUrl={seekingPreviewUrl ?? ""}
+        {...rest}
+      />
     </PlayerErrorBoundary>
   )
 }

--- a/apps/web/lib/api/client.ts
+++ b/apps/web/lib/api/client.ts
@@ -1,6 +1,11 @@
+// Base URL for server-side fetches (server components, route handlers).
+// Prefers `API_URL` so docker SSR can reach the API via the internal
+// hostname `http://api:4000`; the browser never sees `API_URL` because
+// Next only inlines `NEXT_PUBLIC_*` — it resolves to `undefined` there and
+// falls through to the public URL.
 export const API_BASE_URL =
-  process.env.NEXT_PUBLIC_API_URL ??
   process.env.API_URL ??
+  process.env.NEXT_PUBLIC_API_URL ??
   "http://localhost:4000"
 
 export class ApiError extends Error {
@@ -66,7 +71,3 @@ export function apiUpload<T>(
   })
 }
 
-/** Prefix a path returned by the API (e.g. "/videos/1/stream") with API_BASE_URL. */
-export function apiUrl(path: string): string {
-  return `${API_BASE_URL}${path}`
-}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -50,8 +50,14 @@ services:
     # Cap CPU so request handling (uploads especially) can't starve the host.
     cpus: 1.5
     mem_limit: 1g
+    # oven/bun:1-alpine doesn't ship curl, so use bun itself for the probe —
+    # zero extra image size, always present (it's the runtime).
     healthcheck:
-      test: ["CMD", "curl", "-f", "http://localhost:4000/health"]
+      test:
+        - CMD
+        - bun
+        - -e
+        - fetch('http://localhost:4000/health').then(r=>process.exit(r.ok?0:1)).catch(()=>process.exit(1))
       interval: 10s
       timeout: 5s
       retries: 3


### PR DESCRIPTION
## Summary

Two related bugs that surface together when running the full docker stack.

### 1. API container stuck unhealthy → web never starts

\`api\` healthcheck invoked \`curl\`, but \`oven/bun:1-alpine\` doesn't ship curl:

\`\`\`
OCI runtime exec failed: exec: "curl": executable file not found in $PATH
\`\`\`

\`web\` declares \`depends_on: api { condition: service_healthy }\` so it never boots. Swap the healthcheck for a \`bun -e\` one-liner — bun is guaranteed present (it's the runtime) and adds zero image size.

### 2. SSR baked docker-internal URLs into markup

\`watch/page.tsx\` called \`apiUrl(res.video.hlsUrl)\` server-side, which produced \`http://api:4000/videos/46/hls/master.m3u8\` (because \`API_URL\` was preferred for docker). That URL went into the HTML the browser received, and the browser couldn't resolve the \`api\` hostname — page rendered "Failed to load video".

Fix by moving the public-host prefix into \`LazyPlayer\` (already a client component). Server passes plain paths; client prepends \`NEXT_PUBLIC_API_URL\` at render time. The watch page is still SSR'd; only the \`<video src>\` string is built client-side, and hls.js attaches its src after mount anyway.

Side benefit: changing \`NEXT_PUBLIC_API_URL\` no longer requires an SSR rebuild — the markup is host-agnostic.

## Changes

- \`docker-compose.yml\` — healthcheck uses \`bun -e fetch(...)\`
- \`apps/web/lib/api/client.ts\` — drop \`apiUrl()\` and \`PUBLIC_API_URL\`. Single \`API_BASE_URL\` remains, used only by \`apiFetch\` / \`apiUpload\` (prefers \`API_URL\`, falls back to \`NEXT_PUBLIC_API_URL\`)
- \`apps/web/components/player/lazy-player.tsx\` — rename \`videoUrl\`/\`hlsUrl\` props → \`videoPath\`/\`hlsPath\`; add \`withBase()\` that prefixes relative paths and leaves absolute URLs (presigned MinIO) untouched
- \`apps/web/app/watch/page.tsx\` — pass raw paths from the API response

## Test plan

- [x] \`docker compose up -d api web\` → \`api Healthy\`, \`web Running\`
- [ ] \`docker inspect api --format '{{.State.Health.Status}}'\` → \`healthy\`
- [ ] \`/watch?v=<id>\` loads the player without "fetch failed"
- [ ] Network tab: video + HLS requests go to \`localhost:4000\` (not \`api:4000\`)
- [ ] Videos list and delete still work (server + client fetches go through \`API_BASE_URL\`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)