### PR TITLE
docs(context): refresh onboarding docs for refactor, Eden Treaty, URL split

### DIFF
--- a/.claude/context/architecture.md
+++ b/.claude/context/architecture.md
@@ -39,11 +39,17 @@ storage → playback) or where a piece of state lives.
    [`uploadStreamToRawBucket`](../../packages/shared/src/storage/index.ts) — the
    API process never buffers the entire video. See
    [apps/api/src/modules/upload/service.ts](../../apps/api/src/modules/upload/service.ts).
-3. The API inserts a row in PostgreSQL with `status: pending`.
-4. The API publishes three jobs to RabbitMQ:
+3. The API inserts a row in PostgreSQL with `status: pending` via
+   [`videoRepository.create`](../../apps/api/src/modules/videos/repository.ts).
+4. The API publishes three ingest jobs to RabbitMQ through
+   [`uploadJobPublisher.publishIngestJobs`](../../apps/api/src/modules/upload/job-publisher.ts)
+   (one call — fans out to all three queues):
    - `video.thumbnail` → extract a frame at 1s
    - `video.seeking-preview` → generate a sprite sheet
    - `video.transcode` → generate multi-variant HLS streams
+5. The API response exposes only a projected view of the new row
+   (`id`, `title`, `status`, `createdAt`, `updatedAt`) — internal fields
+   like `rawPath` and error messages never cross the API boundary.
 
 > The upload route deliberately bypasses Elysia's `t.File()` body validator
 > (it has been unstable for large multipart uploads across Elysia versions) and
@@ -53,10 +59,16 @@ storage → playback) or where a piece of state lives.
 ## Worker flow
 
 Workers are **split into separate processes per job type** for independent
-scaling and resource isolation. Shared logic (generic consumer with
-retry/ack, race-safe video status updates, `probeVideo`/`probeDuration`
-ffprobe wrappers, `runFFmpeg` spawn helper) lives in
-[packages/worker-core](../../packages/worker-core).
+scaling and resource isolation. Each worker's `src/index.ts` is a thin
+recipe that calls [`startWorker`](../../packages/worker-core/src/runtime.ts)
+— the runtime opens DB + RabbitMQ, registers a consumer with retry + graceful
+drain on SIGTERM, and hands the handler a child logger tagged with
+`{ queue, videoId, attempt }`. Handlers use
+[`withTempDir`](../../packages/worker-core/src/tmp.ts) for scratch space and
+[`createFFmpegProgressTracker`](../../packages/worker-core/src/ffmpeg-progress.ts)
+to parse FFmpeg stderr for progress. DB writes go through
+[`updateVideoField`](../../packages/worker-core/src/video-state.ts), which
+race-safely transitions `status` once all three workers report done.
 
 5. Each worker process consumes one job at a time (`ch.prefetch(1)`) and
    runs FFmpeg with `-threads 1` to keep CPU bounded. Since each handler is
@@ -99,8 +111,16 @@ ffprobe wrappers, `runFFmpeg` spawn helper) lives in
 
 ## Playback flow
 
-11. The Web app fetches video metadata from the API, including presigned
-    MinIO URLs and the HLS playlist URL.
+11. The Web app fetches video metadata from the API through the Eden Treaty
+    client in [apps/web/lib/api/](../../apps/web/lib/api) — request and
+    response types are inferred from the API's route tree at
+    [apps/api/src/index.ts](../../apps/api/src/index.ts), so the web never
+    redeclares response shapes. The response carries presigned MinIO URLs
+    for thumbnail + sprite preview, and **relative paths** for video stream
+    and HLS playlist (`/videos/46/stream`, `/videos/46/hls/master.m3u8`).
+    Paths are prefixed with `NEXT_PUBLIC_API_URL` at render time inside
+    `LazyPlayer` (a client component), so SSR markup is host-agnostic and
+    Docker-internal hostnames never leak into HTML.
 12. When HLS is available (`hlsUrl` is set), the frontend uses **hls.js** for
     adaptive bitrate streaming. hls.js fetches the master `.m3u8` from the API
     (`GET /videos/:id/hls/*`), which proxies files from MinIO. The HLS endpoint

--- a/.claude/context/conventions.md
+++ b/.claude/context/conventions.md
@@ -17,8 +17,10 @@ the repo.
 - **Don't modify the DB schema without a migration** — always run
   `bunx drizzle-kit generate` after editing
   [packages/shared/src/database/schema.ts](../../packages/shared/src/database/schema.ts).
-- **API runtime is Bun, not Node.js** — prefer `Bun.env`, `Bun.spawn`, etc.
-  when the Bun API is cleaner or required.
+- **API runtime is Bun, not Node.js** — prefer `Bun.spawn`, `Bun.file`, etc.
+  when the Bun API is cleaner or required. For env access use `process.env`
+  (Bun populates it); `Bun.env` in `packages/shared` would break Next's tsc
+  when it walks into the shared package via the `App` type import.
 - **Web app uses `@workspace/ui/*` for shared components** — never duplicate
   UI components into [apps/web](../../apps/web). Add new shared primitives to
   [packages/ui](../../packages/ui).
@@ -48,16 +50,40 @@ the repo.
 - **Worker shared utilities** — `probeVideo`, `probeDuration`, and `runFFmpeg`
   live in `@workspace/worker-core`. Don't duplicate ffprobe/ffmpeg logic in
   individual worker handlers.
-- **Workers use graceful shutdown** — `registerConsumer` returns a
-  `ConsumerHandle` with a `drain()` method. On SIGTERM, call `drain()` to
-  finish in-flight jobs before closing the RabbitMQ connection.
+- **Workers use `startWorker`** — `apps/worker-*/src/index.ts` should be a
+  single `await startWorker({ queue, label, handle, onSuccess, onFailed })`
+  call. `startWorker` handles DB + RabbitMQ bootstrap, consumer registration,
+  graceful drain on SIGTERM, and passes a child logger to the handler. Don't
+  hand-wire `initDatabase` / `connectRabbitMQ` / `registerConsumer` in new
+  workers — that boilerplate is what `startWorker` replaced.
+- **Handlers use `withTempDir`** — scratch directories come from
+  `withTempDir(prefix, (dir) => …)`. Don't construct `/tmp/...` paths
+  yourself; cleanup is handled automatically in `finally`.
 - **Retry uses exponential backoff** — failed jobs wait `1s * 2^attempt` before
   requeue.
+- **API errors extend `DomainError`** — for routes, throw a subclass of
+  [`DomainError`](../../apps/api/src/shared/errors.ts) (e.g.
+  `VideoNotFoundError`, `InvalidVideoFormatError`). The
+  [`errorHandler` plugin](../../apps/api/src/shared/error-handler.ts) in
+  `src/index.ts` maps them to HTTP responses. Don't set `set.status` and
+  return `{ error: ... }` manually from routes.
+- **Web API types come from Eden Treaty** — derive request/response types
+  from `apps/web/lib/api/videos.ts` (which uses `treaty<App>`), not by
+  hand-writing interfaces. Rename or reshape an API response? The web code
+  picks it up automatically.
+- **SSR never bakes API host into markup** — server components pass raw
+  API paths (e.g. `/videos/46/stream`) to client components. The client
+  component (`LazyPlayer`) prefixes `NEXT_PUBLIC_API_URL` at render time.
+  Calling a `apiUrl()`-style helper in a server component would freeze a
+  Docker-internal hostname into HTML that the browser can't resolve.
 - **Delete confirmation** — destructive UI actions (e.g. video delete) should
   use `AlertDialog` from `@workspace/ui` for confirmation.
 - **Structured logging** — use `createLogger(service)` from
   `@workspace/shared/logger` for JSON-formatted, level-aware logs. The logger
-  supports `.child({ videoId })` for adding context.
+  supports `.child({ videoId })` for adding context. **Never use `console.*`
+  in app or worker code** — API entry-point, services, workers, and
+  `packages/worker-core` all go through the shared logger. The only
+  exception is the logger itself (it's the transport).
 
 ## Adding shadcn/ui components
 

--- a/.claude/context/data-and-infra.md
+++ b/.claude/context/data-and-infra.md
@@ -65,8 +65,9 @@ bunx drizzle-kit push        # apply schema changes to the DB
 
 Resource caps per service:
 
-- `api`: `cpus: 1.5`, `mem_limit: 1g` — has a Docker healthcheck that curls
-  `/health` every 10s
+- `api`: `cpus: 1.5`, `mem_limit: 1g` — has a Docker healthcheck that probes
+  `/health` every 10s using `bun -e` (the `oven/bun:1-alpine` image doesn't
+  ship curl, and bun is already the runtime)
 - `worker-thumbnail`: `cpus: 0.5`, `mem_limit: 512m` (lightweight, single frame extraction)
 - `worker-preview`: `cpus: 1.5`, `mem_limit: 1g` (CPU-intensive sprite generation)
 - `worker-transcode`: `cpus: 2.0`, `mem_limit: 2g` (CPU-intensive multi-variant HLS encoding)

--- a/.claude/context/workspaces.md
+++ b/.claude/context/workspaces.md
@@ -29,7 +29,7 @@ minitube/
 | [apps/worker-preview](../../apps/worker-preview) | Bun + FFmpeg, sprite-sheet seeking preview (Debian image) |
 | [apps/worker-transcode](../../apps/worker-transcode) | Bun + FFmpeg, multi-variant HLS transcode (Debian image) |
 | [packages/shared](../../packages/shared) | Shared config, Drizzle ORM database, MinIO storage, RabbitMQ, structured logger |
-| [packages/worker-core](../../packages/worker-core) | Generic consumer wrapper, retry/ack with exponential backoff, graceful drain, race-safe video status updates, `probeVideo`/`probeDuration`, `runFFmpeg` |
+| [packages/worker-core](../../packages/worker-core) | `startWorker` runtime (DB + RabbitMQ bootstrap, consumer with retry/ack and graceful drain), `withTempDir`, `createFFmpegProgressTracker`, race-safe `updateVideoField`, `probeVideo` / `probeDuration`, `runFFmpeg` |
 | [packages/ui](../../packages/ui) | Shared shadcn/ui component library (Radix UI primitives) |
 | [packages/eslint-config](../../packages/eslint-config) | Shared ESLint configs |
 | [packages/typescript-config](../../packages/typescript-config) | Shared tsconfig |
@@ -40,9 +40,10 @@ To add a new job type (e.g. `worker-foo`):
 
 1. Add the queue + job type in [packages/shared/src/rabbitmq](../../packages/shared/src/rabbitmq)
 2. Create `apps/worker-<name>/` with `package.json`, `tsconfig.json`, `src/index.ts`, `src/handler.ts`
-3. Use `registerConsumer` from `@workspace/worker-core` to wire handler → queue
-4. Create `docker/worker-<name>.Dockerfile`
-5. Add the service to [docker-compose.yml](../../docker-compose.yml)
+3. `src/index.ts` should be a thin `await startWorker({ queue, label, handle, onSuccess, onFailed })` call. The handler receives `(job, { logger })` — no direct bootstrap or shutdown boilerplate.
+4. In the handler, use `withTempDir` for scratch dirs and (if FFmpeg is involved) `createFFmpegProgressTracker` for stderr parsing.
+5. Create `docker/worker-<name>.Dockerfile`
+6. Add the service to [docker-compose.yml](../../docker-compose.yml)
 
 ## API module pattern
 
@@ -51,18 +52,59 @@ following this convention:
 
 ```
 modules/<name>/
-├── index.ts     → Elysia route definitions (required)
-├── service.ts   → business logic (required)
-└── model.ts     → TypeBox validation schemas (optional — only when the
-                   route benefits from declarative body validation)
+├── index.ts        → Elysia route definitions (required; thin HTTP adapter)
+├── service.ts      → use-case orchestration (required)
+├── repository.ts   → Drizzle queries (optional — when the module owns a table)
+├── storage.ts      → MinIO operations (optional — when the module reads/writes objects)
+├── errors.ts       → domain errors (extend DomainError from shared/errors.ts)
+└── model.ts        → TypeBox validation schemas (optional)
 ```
 
+The service is the use-case layer: it orchestrates repository + storage +
+job-publisher calls and throws domain errors. Routes (`index.ts`) are thin
+HTTP adapters — they call the service and let the global
+[`errorHandler` plugin](../../apps/api/src/shared/error-handler.ts) map
+`DomainError` subclasses to HTTP responses. Cross-cutting concerns
+(`logger`, `errorHandler`, `DomainError` base class) live under
+[apps/api/src/shared/](../../apps/api/src/shared).
+
 Current modules: `health`, `upload`, `videos`.
+
+Example: the upload module has `service.ts` (validates, streams, inserts),
+`job-publisher.ts` (fans out ingest jobs to all three worker queues in one
+call), and `index.ts` (route). The videos module has `repository.ts` for
+Drizzle, `storage.ts` for MinIO ops, `errors.ts` for `VideoNotFoundError`
+etc., and `service.ts` orchestrating them.
 
 > Note: `upload` does **not** have a `model.ts`. The upload route reads
 > `request.formData()` directly and validates with magic bytes in the service,
 > because Elysia's `t.File()` body validator has been unstable for large
 > multipart uploads across versions.
+
+## Web ↔ API types (Eden Treaty)
+
+[apps/api/src/index.ts](../../apps/api/src/index.ts) exports
+`type App = typeof app`. The web workspace imports it via
+`import type { App } from "api/app"` (exposed through
+`apps/api/package.json` `"./app"`) and constructs a typed client with
+`treaty<App>(...)`. All request/response types used in
+[apps/web/lib/api/](../../apps/web/lib/api) and
+[apps/web/services/video/types.ts](../../apps/web/services/video/types.ts)
+are derived from the Elysia route tree via `Awaited<ReturnType<...>>` —
+**never hand-write an API response interface in web code**.
+
+Two URL constants exist for a reason:
+
+- `API_BASE_URL` in `lib/api/client.ts` — used by the treaty client and
+  `apiUpload` for actual fetches. On server, prefers `API_URL`
+  (docker-internal `http://api:4000`); on the client, `API_URL` is
+  undefined and it falls through to `NEXT_PUBLIC_API_URL`.
+- `NEXT_PUBLIC_API_URL` — inlined into the client bundle by Next, used
+  inside client components like `LazyPlayer` when an API path needs to be
+  rendered into HTML (`<video src>`, HLS playlist). Server components
+  should pass **relative paths** to client components; never call a helper
+  that prefixes the public host during SSR — the result will be baked into
+  markup and the browser will fail to resolve Docker-internal hostnames.
 
 ## Path aliases
 
@@ -74,7 +116,8 @@ Current modules: `health`, `upload`, `videos`.
   - `@workspace/shared/storage`
   - `@workspace/shared/rabbitmq`
   - `@workspace/shared/logger`
-  - `@workspace/worker-core` (consumer, video-state, probe, ffmpeg — workers only)
+  - `@workspace/worker-core` (`startWorker`, `withTempDir`, `createFFmpegProgressTracker`, `registerConsumer`, `updateVideoField`, `probeVideo`/`probeDuration`, `runFFmpeg` — workers only)
+- Web-only: `api/app` (Eden Treaty — import `type { App }` to derive typed clients from the Elysia route tree)
 
 ## Config & environment
 
@@ -82,11 +125,18 @@ Shared config lives in
 [packages/shared/src/config/index.ts](../../packages/shared/src/config/index.ts).
 It:
 
-- manually parses `.env` (no dotenv dependency),
+- manually reads `.env` (no dotenv dependency) and populates `process.env`,
+- validates every variable through a **zod schema** so missing or malformed
+  env values fail fast at startup with the offending field name,
 - detects Docker via `/.dockerenv`, and
 - auto-resolves container hostnames (`db`, `minio`, `rabbitmq`) to `localhost`
   when running outside Docker, so the same `.env` works both in and out of
   Compose.
+
+> `packages/shared` intentionally reads from `process.env` (not `Bun.env`) so
+> Next's tsc can walk into it via the `App` type import without needing
+> `bun-types`. Bun populates `process.env` identically, so the behaviour is
+> unchanged inside API and worker runtimes.
 
 Env file locations:
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -78,10 +78,18 @@ The ones you must not forget:
 - **Shared logic lives in [packages/shared](./packages/shared)**, imported via
   `@workspace/shared/{config,database,storage,rabbitmq,logger}`.
 - **Worker shared logic lives in [packages/worker-core](./packages/worker-core)** —
-  new worker apps should use `registerConsumer` + `updateVideoField` from
-  `@workspace/worker-core`. Shared utilities `probeVideo`, `probeDuration`,
-  and `runFFmpeg` are also exported from worker-core.
-- **Graceful shutdown** — workers call `consumer.drain()` on SIGTERM to finish
-  in-flight jobs before exiting.
+  new worker apps call `startWorker` from `@workspace/worker-core`, which
+  bootstraps DB + RabbitMQ, wires a consumer with retry + graceful drain, and
+  hands the handler a child logger. Handlers use `withTempDir` for scratch
+  space and `createFFmpegProgressTracker` + `runFFmpeg` for encoding; ffprobe
+  lives behind `probeVideo` / `probeDuration`. DB writes go through
+  `updateVideoField` (race-safe status transitions).
 - **Retry backoff** — failed jobs use exponential backoff (1s, 2s, 4s…) before
   requeue.
+- **Web ↔ API types via Eden Treaty** — `apps/api/src/index.ts` exports
+  `type App = typeof app`; the web client in [apps/web/lib/api/](./apps/web/lib/api)
+  derives request/response types from it, so there is no hand-written schema
+  layer. Don't re-declare API response shapes in web code.
+- **Logging is structured** — never use `console.*` in app code. Create a
+  child logger from `@workspace/shared/logger` and pass context via
+  `logger.child({ videoId })`.


### PR DESCRIPTION
## Summary

Bring the \`.claude/context/\` docs and \`CLAUDE.md\` in line with what's actually in the code after the recent refactor rounds. No code changes.

## What moved

### architecture.md
- **Upload flow**: now references \`uploadJobPublisher.publishIngestJobs\` (one call, three queues) and notes the API returns a projected 5-field video instead of the raw DB row
- **Worker flow**: rewritten around \`startWorker\`, \`withTempDir\`, and \`createFFmpegProgressTracker\` (the old hand-wired bootstrap is gone from the code, so the doc shouldn't describe it)
- **Playback flow**: calls out Eden Treaty + the SSR-pass-paths / client-prefix pattern

### workspaces.md
- API module pattern expanded to cover \`repository.ts\`, \`storage.ts\`, \`errors.ts\`, \`apps/api/src/shared/\`
- New **Web ↔ API types (Eden Treaty)** section — explains \`type App = typeof app\`, \`treaty<App>\`, and the \`API_BASE_URL\` vs \`NEXT_PUBLIC_API_URL\` story
- "Adding a new worker" updated to use \`startWorker\`
- Config section: mentions zod env validation and the \`process.env\`-over-\`Bun.env\` decision (so Next's tsc can walk into shared)

### conventions.md
- New rules: \`DomainError\` discipline, Eden-derived types (don't re-declare API responses in web), SSR-never-bakes-API-host, \`startWorker\` + \`withTempDir\` for workers/handlers
- Tighten the structured-logging rule: no \`console.*\` in app code

### data-and-infra.md
- Healthcheck note: \`bun -e\` (alpine-bun ships without curl)

### CLAUDE.md
- Worker rule swaps to \`startWorker\`
- Adds Eden Treaty + no-console rules

## Test plan

- [x] No source code touched — \`pnpm typecheck\` / \`pnpm lint\` unchanged
- [ ] Links in docs resolve (reviewer can eyeball)

🤖 Generated with [Claude Code](https://claude.com/claude-code)