### PR TITLE
test(web): add tests for formatTime and unwrap / ApiError

### DIFF
--- a/apps/web/lib/api/client.test.ts
+++ b/apps/web/lib/api/client.test.ts
@@ -1,0 +1,85 @@
+import { describe, it, expect } from "vitest"
+import { ApiError, unwrap } from "./client"
+
+describe("ApiError", () => {
+  it("carries a message and status", () => {
+    const err = new ApiError("boom", 418)
+    expect(err.message).toBe("boom")
+    expect(err.status).toBe(418)
+    expect(err.name).toBe("ApiError")
+    expect(err).toBeInstanceOf(Error)
+  })
+})
+
+describe("unwrap", () => {
+  it("returns data when there is no error", () => {
+    expect(unwrap({ data: { id: 1 }, error: null })).toEqual({ id: 1 })
+  })
+
+  it("passes null data through when there is no error", () => {
+    // Valid server response — caller is expected to narrow.
+    expect(unwrap({ data: null, error: null })).toBeNull()
+  })
+
+  it("throws ApiError with the server-provided error string when present", () => {
+    expect(() =>
+      unwrap({
+        data: null,
+        error: { status: 404, value: { error: "Video not found" } },
+      })
+    ).toThrowError(
+      expect.objectContaining({
+        name: "ApiError",
+        message: "Video not found",
+        status: 404,
+      })
+    )
+  })
+
+  it("falls back to a generic message when value has no .error field", () => {
+    expect(() =>
+      unwrap({ data: null, error: { status: 500, value: { foo: "bar" } } })
+    ).toThrowError(
+      expect.objectContaining({
+        message: "Request failed (500)",
+        status: 500,
+      })
+    )
+  })
+
+  it("uses status 500 when the status is not a number", () => {
+    expect(() =>
+      unwrap({ data: null, error: { status: "oops", value: null } })
+    ).toThrowError(
+      expect.objectContaining({
+        message: "Request failed (500)",
+        status: 500,
+      })
+    )
+  })
+
+  it("ignores non-string .error values", () => {
+    expect(() =>
+      unwrap({
+        data: null,
+        error: { status: 400, value: { error: { nested: true } } },
+      })
+    ).toThrowError(
+      expect.objectContaining({
+        message: "Request failed (400)",
+        status: 400,
+      })
+    )
+  })
+
+  it("handles a null value without crashing", () => {
+    expect(() =>
+      unwrap({ data: null, error: { status: 502, value: null } })
+    ).toThrowError(
+      expect.objectContaining({
+        message: "Request failed (502)",
+        status: 502,
+      })
+    )
+  })
+})

--- a/apps/web/lib/format-time.test.ts
+++ b/apps/web/lib/format-time.test.ts
@@ -1,0 +1,44 @@
+import { describe, it, expect } from "vitest"
+import { formatTime } from "./format-time"
+
+describe("formatTime", () => {
+  it.each([
+    [0, "0:00"],
+    [1, "0:01"],
+    [9, "0:09"],
+    [10, "0:10"],
+    [59, "0:59"],
+    [60, "1:00"],
+    [61, "1:01"],
+    [125, "2:05"],
+    [599, "9:59"],
+    [600, "10:00"],
+    [3599, "59:59"],
+  ])("formats %i seconds as %s (mm:ss)", (seconds, expected) => {
+    expect(formatTime(seconds)).toBe(expected)
+  })
+
+  it.each([
+    [3600, "1:00:00"],
+    [3661, "1:01:01"],
+    [7325, "2:02:05"],
+    [36000, "10:00:00"],
+  ])("formats %i seconds as %s (h:mm:ss)", (seconds, expected) => {
+    expect(formatTime(seconds)).toBe(expected)
+  })
+
+  it("floors fractional seconds", () => {
+    expect(formatTime(12.7)).toBe("0:12")
+  })
+
+  it("clamps negative values to zero", () => {
+    expect(formatTime(-5)).toBe("0:00")
+  })
+
+  it.each([NaN, Infinity, -Infinity])(
+    "returns 0:00 for non-finite input %p",
+    (value) => {
+      expect(formatTime(value)).toBe("0:00")
+    }
+  )
+})


### PR DESCRIPTION
## Summary

Follow-up to #19 — expand web test coverage to the two other pure helpers in \`apps/web/lib/\`.

### \`lib/format-time.ts\`
- Boundary cases across \`mm:ss\` / \`h:mm:ss\` formats
- Fractional seconds (floors)
- Negative input (clamps to 0)
- Non-finite values (\`NaN\` / \`±Infinity\` → \`0:00\`)

### \`lib/api/client.ts\`
- \`ApiError\` carries \`message\` + \`status\` + proper \`name\`, and extends \`Error\`
- \`unwrap\` returns data on success
- Extracts \`value.error\` as the message when the server provides it
- Falls back to \`Request failed ({status})\` when the value has no string \`.error\`
- Coerces non-numeric status codes to 500
- Handles \`null\` value without crashing
- Ignores non-string \`.error\` values (e.g. a nested object)

## Totals

- Web suite: **44 tests** (was 16)
- Full suite: **55 tests** across api (11) + web (44)

## Test plan

- [x] \`pnpm --filter web test\` → 44 passed in one file → three files
- [x] CI \`test\` job green

🤖 Generated with [Claude Code](https://claude.com/claude-code)